### PR TITLE
Prevent out of bounds read and DoS vulnerability CVE-2017-11367

### DIFF
--- a/shoco.c
+++ b/shoco.c
@@ -185,7 +185,7 @@ size_t shoco_decompress(const char * const shoco_restrict original, size_t compl
       }
 
       *o++ = *in++;
-    } else {
+    } else if (mark < 3) {
       if (o + packs[mark].bytes_unpacked > out_end)
         return bufsize + 1;
       else if (in + packs[mark].bytes_packed > in_end)
@@ -212,6 +212,8 @@ size_t shoco_decompress(const char * const shoco_restrict original, size_t compl
 
       o += packs[mark].bytes_unpacked;
       in += packs[mark].bytes_packed;
+    } else {
+      break;
     }
   }
 

--- a/tests.c
+++ b/tests.c
@@ -104,6 +104,12 @@ int main() {
   ret = shoco_decompress("\xe0""ab", 3, buf_large, 4096);
   assert(ret == SIZE_MAX);
 
+  ret = shoco_decompress("\xf8", 1, buf_large, 4096);
+  assert(ret == 0);
+
+  ret = shoco_decompress("\xf8""ab", 3, buf_large, 4096);
+  assert(ret == 0);
+
   puts("All tests passed.");
   return 0;
 }


### PR DESCRIPTION
Ensure header mark is within 0-2 range, bail otherwise